### PR TITLE
第２章 課題② - 対策① 攻撃のたびに敵に向かって回転させる

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2834,6 +2834,7 @@ MonoBehaviour:
   _inputVirtualJoyStick: {fileID: 736578144}
   _maxSpeed: 3
   _attacker: {fileID: 1497645982}
+  _attackRotateSpeed: 180
 --- !u!95 &3172645344870299906 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 9500000, guid: a58d63122b09e9144938cd6a1ece4824, type: 3}

--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -34,4 +34,32 @@ public class EnemyManager : MonoBehaviour {
             GameUIManager.Instance.GameEndView.Play(true);
         }
     }
+
+    /// <summary>最寄りの敵を取得する</summary>
+    /// <param name="searchCenter">探査中心座標</param>
+    /// <param name="range">探査範囲</param>
+    public Enemy GetNearestEnemy(Vector3 searchCenter, float range) {
+        // 最寄りの敵を格納するローカル変数
+        Enemy nearestEnemy = null;
+        // 最寄りの敵との距離を格納するローカル変数
+        float nearestDiatance = float.MaxValue;
+        
+        foreach (var enemy in _enemies) {
+            // 敵と探査中心の距離を計算
+            var distance = Vector3.Distance(enemy.transform.position, searchCenter);
+            
+            // 距離が探査範囲外なら無視する
+            if (distance > range) {
+                continue;
+            }
+
+            // 計算した距離が、暫定の最寄り敵との距離より近ければ最寄りの敵情報を更新する
+            if (distance < nearestDiatance) {
+                nearestDiatance = distance;
+                nearestEnemy = enemy;
+            }
+        }
+
+        return nearestEnemy;
+    }
 }


### PR DESCRIPTION
# 実装概要
3D空間で攻撃したい対象に向きを合わせるのが難しい問題の対策として
攻撃開始時に一定範囲内に敵がいた場合
攻撃終了まで（`_attackFlag`が降りるまで）対象の敵に向きを合わせるよう
transformを回転させる実装です。

# 補足
敵に向きを合わせる操作テクニックでプレイヤーの上手い・下手が出るように
攻撃中に**必ず敵に向きを合わせることは保証していません。**
あくまで攻撃終了までの間`_attackRotateSpeed `の回転速度で敵に向かって体を回す、という仕様です。