### PR TITLE
FIX 死亡している敵は探査されないようにする

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -23,6 +23,9 @@ public class Enemy : MonoBehaviour {
     /// <summary>ダメージ中フラグ</summary>
     private bool _damageFlag;
 
+    /// <summary>死亡しているか否か</summary>
+    public bool IsDead => _hp <= 0;
+
     /// <summary>起動時の処理</summary>
     private void Awake() {
         _animator.SetBool("IsMove", true);

--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -45,6 +45,11 @@ public class EnemyManager : MonoBehaviour {
         float nearestDiatance = float.MaxValue;
         
         foreach (var enemy in _enemies) {
+            // 死亡している敵は無視する
+            if (enemy.IsDead) {
+                continue;
+            }
+            
             // 敵と探査中心の距離を計算
             var distance = Vector3.Distance(enemy.transform.position, searchCenter);
             


### PR DESCRIPTION
* [第２章 課題② - 対策① 攻撃のたびに敵に向かって回転させる](https://github.com/fluncle/GCC2023ActionGame/pull/3)

上記PRのバグ修正。
攻撃対象を探す際、HPが0になっていてまだ削除されていない敵を
選んでしまうことがあったため、表題のとおりの修正を入れました。