### PR TITLE
第２章 課題② - 対策② 攻撃のたびに前進させる

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2835,6 +2835,8 @@ MonoBehaviour:
   _maxSpeed: 3
   _attacker: {fileID: 1497645982}
   _attackRotateSpeed: 180
+  _attackAdvanceDistance: 1.5
+  _attackAdvanceMaxSpeed: 8
 --- !u!95 &3172645344870299906 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 9500000, guid: a58d63122b09e9144938cd6a1ece4824, type: 3}


### PR DESCRIPTION
# 実装概要
攻撃時、`transform.forward`の方向に前進する機能。

攻撃時に最寄りの向きを合わせる機能と合わせて
3D空間で敵との距離感が測れていなくても攻撃を何度か素振りしていれば
いつかヒットできるようにすることが目的の実装です。

# 補足１：移動のイージング
攻撃による前進距離を`_attackAdvanceDistance`によって決めていて、
残り移動距離が少ないほど前進速度が落ちる、つまりイージングのような動きになるよう実装しています。

DOTweenを使えばもっとシンプルに実装できますが、DOTweenの説明は３章に回すべきだと考えたため
このような実装にしました。

# 補足２：敵を通り過ぎないようにするサポート実装
`Player.cs`150行からのif分は、攻撃目標の敵がいる場合に
攻撃の前進によって、敵を通り過ぎてしまわないようにする実装です。

ちょっとややこしいので、この部分は純粋な前進処理と分けて解説したほうがよさそうですね。