### PR TITLE
第３章 課題① - 対策①' ダメージ量表示にアニメーションをつける

### DIFF
--- a/Assets/Data/Damage/DamageView.prefab
+++ b/Assets/Data/Damage/DamageView.prefab
@@ -36,7 +36,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 150}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 200, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1600904711486772370
@@ -147,3 +147,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _text: {fileID: 605410681794790550}
+  _moveRoot: {fileID: 4537995727354515146}

--- a/Assets/Scripts/DamageView.cs
+++ b/Assets/Scripts/DamageView.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using DG.Tweening;
 
 public class DamageView : MonoBehaviour {
     /// <summary>ダメージ量のテキスト</summary>
@@ -7,6 +8,9 @@ public class DamageView : MonoBehaviour {
 
     /// <summary>表示するワールド座標</summary>
     private Vector3 _playPosition;
+
+    /// <summary>移動アニメーションのRootオブジェクト</summary>
+    [SerializeField] private Transform _moveRoot; 
 
     /// <summary>再生</summary>
     /// <param name="damage">ダメージ量</param>
@@ -17,6 +21,13 @@ public class DamageView : MonoBehaviour {
         // 表示位置を更新
         _playPosition = worldPosition;
         Update();
+
+        // 上方向に対して±30°のランダムな角度のベクトルを取得
+        var moveVector = Quaternion.Euler(0f, 0f, Random.Range(-30, 30)) * Vector3.up;
+        // 表示を0.3秒で200px動かすアニメーションを作成・再生
+        DOTween.Sequence()
+            .SetLink(gameObject)
+            .Append(_moveRoot.DOLocalMove(moveVector * 200f, 0.3f).SetEase(Ease.OutCubic));
         
         // 0.5秒後に削除処理を呼ぶ
         Invoke(nameof(Destroy), 0.5f);


### PR DESCRIPTION
# 実装概要
ごくシンプルなDOTweenの使用例としての実装です。
去年もあった[数字のアニメーションを自由に作る演習](https://docs.google.com/presentation/d/1VRUgBQuHspSS8w-0xHORwpztb9xfCe7vt4mcGCe900M/edit#slide=id.g1654957806d_0_50)に繋げたいです。