### PR TITLE
第３章 課題① - 対策② HPゲージの差分表示

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -519,7 +519,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 812186143}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -595,7 +595,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 812186143}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -1190,6 +1190,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1908549227}
+  - {fileID: 873492351}
   - {fileID: 548781256}
   - {fileID: 1076363189}
   - {fileID: 594656018}
@@ -1253,6 +1254,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _bar: {fileID: 548781257}
   _valueText: {fileID: 1076363191}
+  _diffBar: {fileID: 873492352}
 --- !u!1 &817051916
 GameObject:
   m_ObjectHideFlags: 0
@@ -1361,6 +1363,82 @@ CanvasGroup:
   m_Interactable: 0
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
+--- !u!1 &873492350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 873492351}
+  - component: {fileID: 873492353}
+  - component: {fileID: 873492352}
+  m_Layer: 5
+  m_Name: DiffBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &873492351
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873492350}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 812186143}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 10, y: 10}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &873492352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873492350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.3137255, b: 0.3137255, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c278181791db7489f8f0230a65e59d17, type: 3}
+  m_Type: 3
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 0
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &873492353
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873492350}
+  m_CullTransparentMesh: 1
 --- !u!4 &935521958 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400090, guid: a58d63122b09e9144938cd6a1ece4824, type: 3}
@@ -1498,7 +1576,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 812186143}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}

--- a/Assets/Scripts/HPGaugeView.cs
+++ b/Assets/Scripts/HPGaugeView.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using DG.Tweening;
 
 public class HPGaugeView : MonoBehaviour {
     /// <summary>ゲージのバー表示のImage</summary>
@@ -8,6 +9,11 @@ public class HPGaugeView : MonoBehaviour {
     /// <summary>HP量を表示するテキスト</summary>
     [SerializeField] private Text _valueText;
     
+    /// <summary>差分ゲージのバー表示のImage</summary>
+    [SerializeField] private Image _diffBar;
+
+    private Sequence _barSeq;
+
     /// <summary>最大HP</summary>
     private int _maxHP;
     
@@ -23,6 +29,13 @@ public class HPGaugeView : MonoBehaviour {
         var hpRate = (float)hp / _maxHP;
         // 残りHPの割合でバーの表示幅を更新
         _bar.fillAmount = hpRate;
+
+        _barSeq?.Kill();
+        _barSeq = DOTween.Sequence()
+            .SetLink(gameObject)
+            .SetDelay(0.75f)
+            .Append(_diffBar.DOFillAmount(hpRate, 0.5f));
+
         // HP量のテキストを更新
         _valueText.text = string.Format("HP {0}/{1}", hp, _maxHP);
     }


### PR DESCRIPTION
# 実装概要
緑のHPゲージの裏に赤いゲージ表示を追加し
HPが減ったときに0.75秒遅れて緑のゲージの長さと同じになるよう
DOTweenで`fillamount`を動かしています。

今回受けたダメージがどれくらいの量なのか
視覚的に分かるようにする目的の機能です。