### PR TITLE
第３章 課題② - 対策② カラー変化による明滅表現

### DIFF
--- a/Assets/Data/Enemy/Prefabs/Slime.prefab
+++ b/Assets/Data/Enemy/Prefabs/Slime.prefab
@@ -529,6 +529,7 @@ MonoBehaviour:
   _attackRange: 1.5
   _attacker: {fileID: 8135465959149887021}
   _hitCollider: {fileID: 1585742122822807295}
+  _bodyRenderer: {fileID: 1585742123493186468}
 --- !u!95 &1585742123497334116
 Animator:
   serializedVersion: 5

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1590,6 +1590,11 @@ MonoBehaviour:
   _target: {fileID: 3172645344870299907}
   _maxSpeed: 10
   _maxSpeedDistance: 2
+--- !u!137 &967407028 stripped
+SkinnedMeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 13700004, guid: a58d63122b09e9144938cd6a1ece4824, type: 3}
+  m_PrefabInstance: {fileID: 202010362}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1076363188
 GameObject:
   m_ObjectHideFlags: 0
@@ -3014,6 +3019,7 @@ MonoBehaviour:
   _attackAdvanceDistance: 1.5
   _attackAdvanceMaxSpeed: 8
   _hitCollider: {fileID: 3172645344870299908}
+  _bodyRenderer: {fileID: 967407028}
 --- !u!95 &3172645344870299906 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 9500000, guid: a58d63122b09e9144938cd6a1ece4824, type: 3}

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using DG.Tweening;
 
 public class Player : MonoBehaviour {
     /// <summary>最大HP</summary>
@@ -43,6 +44,12 @@ public class Player : MonoBehaviour {
 
     /// <summary>喰らい判定のコライダー</summary>
     [SerializeField] private Collider _hitCollider;
+
+    /// <summary>色の点滅演出のシーケンス</summary>
+    private Sequence _blinkColorSeq;
+
+    /// <summary>3Dモデルのレンダラー</summary>
+    [SerializeField] private Renderer _bodyRenderer;
 
     /// <summary>死亡しているか否か</summary>
     public bool IsDead => _hp <= 0;
@@ -229,6 +236,9 @@ public class Player : MonoBehaviour {
         // ヒットエフェクトを再生
         EffectManager.Instance.PlayAttackHit(hitPos + Vector3.up / 2f);
 
+        // ダメージによる点滅表現
+        BlinkColor(new Color(1f, 0.4f, 0.4f));
+
         // HPが0になったの場合、死亡処理に分岐
         if (_hp <= 0) {
             Dead();
@@ -240,6 +250,24 @@ public class Player : MonoBehaviour {
 
         // 0.5秒後にダメージ終了処理を呼び出す
         Invoke(nameof(EndDamage), 0.5f);
+    }
+
+    /// <summary>色点滅の演出を再生</summary>
+    /// <param name="color">点滅の色</param>
+    private void BlinkColor(Color color) {
+        // レンダラーからマテリアルを取得する
+        // TIPS: Rendererのmaterialにアクセスすると、そのタイミングでアタッチされているmaterialが複製され
+        //       Rendererに対してユニークなインスタンスとして扱えます
+        var material = _bodyRenderer.material;
+
+        // 前回の_blinkColorSeqがまだ再生中だった場合を考慮して、演出の強制終了メソッドを呼び出し
+        _blinkColorSeq?.Kill();
+        
+        // 0.1秒で引数の色に変化させ、その後0.15秒で元の色に戻す演出を作成・再生
+        _blinkColorSeq = DOTween.Sequence()
+            .SetLink(gameObject)
+            .Append(DOTween.To(() => Color.white, c => material.SetColor("_Color", c), color, 0.1f))
+            .Append(DOTween.To(() => color, c => material.SetColor("_Color", c), Color.white, 0.15f));
     }
 
     /// <summary>ダメージ終了</summary>


### PR DESCRIPTION
# 実装概要
ダメージ時に、キャラクターのレンダラーにカラーを乗算→すぐに戻して明滅させる演出。
攻撃がヒットしたことをより分かりやすく＝手応えが得られるようにする目的の機能です。