### PR TITLE
第３章 課題② - 対策②' カラー変化による明滅表現（加算版）

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -175,8 +175,8 @@ public class Enemy : MonoBehaviour {
         // 0.1秒で引数の色に変化させ、その後0.15秒で元の色に戻す演出を作成・再生
         _blinkColorSeq = DOTween.Sequence()
             .SetLink(gameObject)
-            .Append(DOTween.To(() => Color.white, c => material.SetColor("_Color", c), color, 0.1f))
-            .Append(DOTween.To(() => color, c => material.SetColor("_Color", c), Color.white, 0.15f));
+            .Append(DOTween.To(() => Color.black, c => material.SetColor("_Color", c), color, 0.1f))
+            .Append(DOTween.To(() => color, c => material.SetColor("_Color", c), Color.black, 0.15f));
     }
 
     /// <summary>ダメージ終了</summary>

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -266,8 +266,8 @@ public class Player : MonoBehaviour {
         // 0.1秒で引数の色に変化させ、その後0.15秒で元の色に戻す演出を作成・再生
         _blinkColorSeq = DOTween.Sequence()
             .SetLink(gameObject)
-            .Append(DOTween.To(() => Color.white, c => material.SetColor("_Color", c), color, 0.1f))
-            .Append(DOTween.To(() => color, c => material.SetColor("_Color", c), Color.white, 0.15f));
+            .Append(DOTween.To(() => Color.black, c => material.SetColor("_Color", c), color, 0.1f))
+            .Append(DOTween.To(() => color, c => material.SetColor("_Color", c), Color.black, 0.15f));
     }
 
     /// <summary>ダメージ終了</summary>

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fec6bbc2c9824423b118eba43eb4e5c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/SurfaceShader-AdditiveColor.shader
+++ b/Assets/Shaders/SurfaceShader-AdditiveColor.shader
@@ -1,0 +1,53 @@
+Shader "Custom/SurfaceShader-AdditiveColor"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (0,0,0,1)
+        _MainTex ("Albedo (RGB)", 2D) = "white" {}
+        _Glossiness ("Smoothness", Range(0,1)) = 0.5
+        _Metallic ("Metallic", Range(0,1)) = 0.0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 200
+
+        CGPROGRAM
+        // Physically based Standard lighting model, and enable shadows on all light types
+        #pragma surface surf Standard fullforwardshadows
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+
+        sampler2D _MainTex;
+
+        struct Input
+        {
+            float2 uv_MainTex;
+        };
+
+        half _Glossiness;
+        half _Metallic;
+        fixed4 _Color;
+
+        // Add instancing support for this shader. You need to check 'Enable Instancing' on materials that use the shader.
+        // See https://docs.unity3d.com/Manual/GPUInstancing.html for more information about instancing.
+        // #pragma instancing_options assumeuniformscaling
+        UNITY_INSTANCING_BUFFER_START(Props)
+            // put more per-instance properties here
+        UNITY_INSTANCING_BUFFER_END(Props)
+
+        void surf (Input IN, inout SurfaceOutputStandard o)
+        {
+            // Albedo comes from a texture tinted by color
+            fixed4 c = tex2D (_MainTex, IN.uv_MainTex) + _Color;
+            o.Albedo = c.rgb;
+            // Metallic and smoothness come from slider variables
+            o.Metallic = _Metallic;
+            o.Smoothness = _Glossiness;
+            o.Alpha = c.a;
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/Assets/Shaders/SurfaceShader-AdditiveColor.shader.meta
+++ b/Assets/Shaders/SurfaceShader-AdditiveColor.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b9934b74804554b9aa4b031f35f29ba6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ThirdParty/DogKnight/Material/Polyart.mat
+++ b/Assets/ThirdParty/DogKnight/Material/Polyart.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Polyart
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: b9934b74804554b9aa4b031f35f29ba6, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -75,6 +75,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 0, g: 0, b: 0, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/ThirdParty/RPG Monster Duo PBR Polyart/Materials/PolyartDefault.mat
+++ b/Assets/ThirdParty/RPG Monster Duo PBR Polyart/Materials/PolyartDefault.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: PolyartDefault
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Shader: {fileID: 4800000, guid: b9934b74804554b9aa4b031f35f29ba6, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -79,7 +79,7 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 0, g: 0, b: 0, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []


### PR DESCRIPTION
# 実装概要
カラー明滅の色の反映を乗算ではなく加算にする実装です。

**乗算だと色が黒に近づき、印象として目立ちづらくなるので加算がおすすめ、というTIPS的なブラッシュアップ差分です。**
他、赤いスライムへの赤乗算はほぼ差分がないが、加算だと白に近づくので気づきやすいという利点があります。

色の加算のために簡単なシェーダーの実装を含みます。
`Create > Shader > Standard Surface Shader`で新規作成するシェーダーの
`_Color`の乗算部分を加算に変えるだけのものです。
講義としてはシェーダー自体の解説には深入りせず、手段としてそういうことができるのと、
HLSLについて理解すると分かるということだけ伝わればOKです

また、おすすめ書籍として下記を紹介できるとよいかなと考えています。
* [HLSL シェーダーの魔導書 | Amazon](https://amzn.asia/d/7DxYSxZ)