### PR TITLE
Rejected

### DIFF
--- a/Assets/Data/Enemy/Prefabs/Slime.prefab
+++ b/Assets/Data/Enemy/Prefabs/Slime.prefab
@@ -526,6 +526,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _animator: {fileID: 1585742123497334116}
   _maxSpeed: 1.5
+  _maxTurnSpeed: 120
   _attackRange: 1.5
   _attacker: {fileID: 8135465959149887021}
   _hitCollider: {fileID: 1585742122822807295}

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -16,7 +16,11 @@ public class Enemy : MonoBehaviour {
     public float MaxSpeed => _maxSpeed;
     [SerializeField] private float _maxSpeed;
 
-    /// <summary>移動最高速度(m/s)</summary>
+    /// <summary>旋回最高速度(m/s)</summary>
+    public float MaxTurnSpeed => _maxTurnSpeed;
+    [SerializeField] private float _maxTurnSpeed;
+
+    /// <summary>攻撃開始距離(m)</summary>
     public float AttackRange => _attackRange;
     [SerializeField] private float _attackRange;
 

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -90,14 +90,6 @@ public class Enemy : MonoBehaviour {
     /// <summary>攻撃判定を無効化</summary>
     private void DisableAttackCollider() {
         _attacker.Collider.enabled = false;
-        // 1秒後に攻撃終了処理を呼び出す
-        Invoke(nameof(EndAttack), 1f);
-    }
-
-    /// <summary>攻撃終了</summary>
-    private void EndAttack() {
-        // 待機状態へ遷移
-        Transition(new EnemyStatePatrol(this));
     }
 
     /// <summary>TriggerのColliderとの接触処理</summary>

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -52,8 +52,8 @@ public class Enemy : MonoBehaviour {
 
     /// <summary>起動時の処理</summary>
     private void Awake() {
-        // 追跡状態から開始
-        _state = new EnemyStatePursue(this);
+        // 待機状態から開始
+        _state = new EnemyStatePatrol(this);
         _hp = MAX_HP;
     }
 
@@ -96,8 +96,8 @@ public class Enemy : MonoBehaviour {
 
     /// <summary>攻撃終了</summary>
     private void EndAttack() {
-        // 追跡状態へ遷移
-        Transition(new EnemyStatePursue(this));
+        // 待機状態へ遷移
+        Transition(new EnemyStatePatrol(this));
     }
 
     /// <summary>TriggerのColliderとの接触処理</summary>

--- a/Assets/Scripts/EnemyState/EnemyStateAttack.cs
+++ b/Assets/Scripts/EnemyState/EnemyStateAttack.cs
@@ -1,11 +1,56 @@
+using UnityEngine;
+
 /// <summary>攻撃状態</summary>
 public class EnemyStateAttack : EnemyStateBase {
+    /// <summary>進捗タイプ</summary>
+    private enum Progress {
+        /// <summary>攻撃前の準備</summary>
+        Ready,
+        /// <summary>攻撃後の硬直</summary>
+        Rigid,
+    }
+
+    /// <summary>準備時間</summary>
+    private const float READY_TIME = 0.5f;
+
+    /// <summary>硬直時間</summary>
+    private const float RIGID_TIME = 1.5f;
+
+    private float _countTime;
+
+    /// <summary>攻撃進行状態</summary>
+    private Progress _progress;
+
     public EnemyStateAttack(Enemy enemy) : base(enemy) { }
 
     /// <summary>このStateに遷移したときに最初に呼び出す処理</summary>
     protected override void Enter() {
         base.Enter();
-        // 攻撃アニメーションのトリガーを起動
-        _enemy.Animator.SetTrigger("Attack");
+        // 進捗を攻撃前の準備へ進める
+        _progress = Progress.Ready;
+    }
+
+    /// <summary>State中に毎フレーム実行する処理</summary>
+    protected override void Update() {
+        base.Update();
+
+        _countTime += Time.deltaTime;
+
+        switch (_progress) {
+            case Progress.Ready:
+                if (_countTime >= READY_TIME) {
+                    // 攻撃アニメーションのトリガーを起動
+                    _enemy.Animator.SetTrigger("Attack");
+                    // 進捗を攻撃後の硬直へ進める
+                    _progress = Progress.Rigid;
+                }
+                break;
+            case Progress.Rigid:
+                if (_countTime >= RIGID_TIME) {
+                    // 待機状態へ遷移
+                    Transition(new EnemyStatePatrol(_enemy));
+                }
+                break;
+        }
     }
 }

--- a/Assets/Scripts/EnemyState/EnemyStateDamage.cs
+++ b/Assets/Scripts/EnemyState/EnemyStateDamage.cs
@@ -51,8 +51,8 @@ public class EnemyStateDamage : EnemyStateBase {
         // ダメージアニメーションのトリガーを起動
         _enemy.Animator.SetTrigger("Damage");
 
-        // ノックバック後に追跡状態へ遷移
-        Action onComplete = () => _enemy.Transition(new EnemyStatePursue(_enemy));
+        // ノックバック後に待機状態へ遷移
+        Action onComplete = () => _enemy.Transition(new EnemyStatePatrol(_enemy));
         _enemy.KnockBack(onComplete);
     }
 }

--- a/Assets/Scripts/EnemyState/EnemyStatePatrol.cs
+++ b/Assets/Scripts/EnemyState/EnemyStatePatrol.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+/// <summary>プレイヤーを探している状態</summary>
+public class EnemyStatePatrol : EnemyStateBase {
+    /// <summary>探査範囲</summary>
+    private const float SEARCH_DISTANCE = 5f;
+
+    public EnemyStatePatrol(Enemy enemy) : base(enemy) { }
+
+    /// <summary>State中に毎フレーム実行する処理</summary>
+    protected override void Update() {
+        base.Update();
+        var player = GameManager.Instance.Player;
+        var distance = Vector3.Distance(_enemy.transform.position, player.transform.position);
+        // プレイヤーとの距離が一定以内になったら追跡を開始
+        if (distance < SEARCH_DISTANCE) {
+            // 追跡状態へ遷移
+            _enemy.Transition(new EnemyStatePursue(_enemy));
+        }
+    }
+}

--- a/Assets/Scripts/EnemyState/EnemyStatePatrol.cs.meta
+++ b/Assets/Scripts/EnemyState/EnemyStatePatrol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfbf9618a14f6476e9ace6b33e1ce705
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemyState/EnemyStatePursue.cs
+++ b/Assets/Scripts/EnemyState/EnemyStatePursue.cs
@@ -19,13 +19,17 @@ public class EnemyStatePursue : EnemyStateBase {
         base.Update();
         var player = GameManager.Instance.Player;
 
-        // プレイヤーの方向を向く
         var playerPos = player.transform.position;
-        _enemy.transform.LookAt(playerPos);
+        var enemyrT = _enemy.transform;
+        var enemyrRot = _enemy.transform.rotation;
+
+        // プレイヤーの方向へ回転
+        var lookRotation = Quaternion.LookRotation(playerPos - enemyrT.position);
+        var turnDegrees = _enemy.MaxTurnSpeed * Time.deltaTime;
+        _enemy.transform.rotation = Quaternion.RotateTowards(enemyrRot, lookRotation, turnDegrees);
 
         // プレイヤーが攻撃範囲にいたら攻撃を実行
-        var currentPos = _enemy.transform.position;
-        var distance = Vector3.Distance(currentPos, playerPos);
+        var distance = Vector3.Distance(enemyrT.position, playerPos);
         if (distance <= _enemy.AttackRange) {
             // 攻撃時は移動処理をせず処理を抜ける
             _enemy.Transition(new EnemyStateAttack(_enemy));
@@ -39,9 +43,9 @@ public class EnemyStatePursue : EnemyStateBase {
             return;
         }
 
-        // プレイヤーに向かって移動
-        var maxDistanceDelta = _enemy.MaxSpeed * Time.deltaTime;
-        _enemy.transform.position = Vector3.MoveTowards(currentPos, playerPos, maxDistanceDelta);
+        // 前方へ移動
+        var moveDistance = _enemy.MaxSpeed * Time.deltaTime;
+        _enemy.transform.position += _enemy.transform.forward * moveDistance;
     }
 
     /// <summary>Stateを抜けるときの処理</summary>

--- a/Assets/Scripts/EnemyState/EnemyStatePursue.cs
+++ b/Assets/Scripts/EnemyState/EnemyStatePursue.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 /// <summary>プレイヤーを追いかける状態</summary>
 public class EnemyStatePursue : EnemyStateBase {
+    /// <summary>追跡を諦める距離</summary>
+    private const float CANCEL_DISTANCE = 5f;
+    
     public EnemyStatePursue(Enemy enemy) : base(enemy) { }
 
     /// <summary>このStateに遷移したときに最初に呼び出す処理</summary>
@@ -26,6 +29,13 @@ public class EnemyStatePursue : EnemyStateBase {
         if (distance <= _enemy.AttackRange) {
             // 攻撃時は移動処理をせず処理を抜ける
             _enemy.Transition(new EnemyStateAttack(_enemy));
+            return;
+        }
+
+        // 一定距離以上プレイヤーから離れたら追跡をやめる
+        if (distance > CANCEL_DISTANCE) {
+            // パトロール状態へ遷移
+            _enemy.Transition(new EnemyStatePatrol(_enemy));
             return;
         }
 


### PR DESCRIPTION
# 第４章 課題② - 敵の行動の調整・追加

# 実装概要

パラメータの違いで敵のバリエーションを出せるように、
状態の追加と各種行動の調整・パラメータを外出しを実施しています。

#### ▼パトロール状態を追加
プレイヤーが一定範囲に近づくまでその場で待機する状態です。

#### ▼攻撃前の予備動作と硬直時間を追加
プレイヤーに攻撃が届く範囲に入ってから攻撃モーションを再生するまでの待ち時間と、
攻撃後に移動も攻撃もしない硬直時間を実装しています。
攻撃テンポの違いで敵の個性出しをする目的の実装です。

#### ▼旋回速度を追加
プレイヤー追跡状態時の移動は、常にプレイヤーにまっすぐ向きを合わせて直線的になっていましたが
プレイヤーに体を回転させる速度を定義して、小回りが効く敵・大回りでないと移動できない敵というような
個性出しが出来るようにする目的の実装です。