### PR TITLE
第４章 課題① - 敵の攻撃前の行動をブラッシュアップ

### DIFF
--- a/Assets/Data/Enemy/Animator/Slime.controller
+++ b/Assets/Data/Enemy/Animator/Slime.controller
@@ -149,7 +149,7 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 8254c95c1caa1da4cb1d22972c413dad, type: 3}
+  m_Motion: {fileID: 3060872287085348379, guid: 8254c95c1caa1da4cb1d22972c413dad, type: 3}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -176,6 +176,33 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: f76b9b823f2fc9a469d0c2c780514380, type: 3}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-3343973550407601549
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AttackReady
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 7234818367997125070}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: -998496362607748373, guid: 8254c95c1caa1da4cb1d22972c413dad, type: 3}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -231,6 +258,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-165073848311246481
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AttackReady
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -3343973550407601549}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.1
+  m_TransitionOffset: 0
+  m_ExitTime: 0.1
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -245,25 +297,31 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsMove
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Dead
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
+  - m_Name: AttackReady
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -277,31 +335,6 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
---- !u!1101 &550201065309576612
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Attack
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -5757599564213651695}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.2
-  m_TransitionOffset: 0
-  m_ExitTime: 0.1
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1107 &1107040346203751106
 AnimatorStateMachine:
   serializedVersion: 6
@@ -326,11 +359,14 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -4747795550666295423}
     m_Position: {x: 330, y: -100, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3343973550407601549}
+    m_Position: {x: 100, y: 190, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 4107871907453793051}
-  - {fileID: 550201065309576612}
   - {fileID: -6376966644550636594}
+  - {fileID: -165073848311246481}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -360,6 +396,53 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0.1
   m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &7234818367997125070
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5757599564213651695}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &7950929645894253645
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6409936378461833460}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -100,6 +100,8 @@ public class Enemy : MonoBehaviour {
         _animator.SetBool("IsMove", false);
         // 攻撃準備表現として、体を3回点滅させる
         FadeColor(Color.gray, 3);
+        // 攻撃準備表現として、体を振動させる
+        ShakeBody(2);
         // 0.1秒後に攻撃判定を無効にする処理を呼び出す
         Invoke(nameof(Attack), 0.3f);
     }
@@ -132,6 +134,8 @@ public class Enemy : MonoBehaviour {
         _attacker.Collider.enabled = false;
         // 攻撃準備表現の点滅を停止する
         _blinkColorSeq?.Complete();
+        // 攻撃準備表現の振動を停止する
+        _shakeSeq?.Complete();
         // 1秒後に攻撃終了処理を呼び出す
         Invoke(nameof(EndAttack), 1f);
     }
@@ -259,6 +263,19 @@ public class Enemy : MonoBehaviour {
             .Append(DOTween.Shake(() => Vector3.zero, offset => _shakeOffset = offset, 0.5f, 0.25f, 30))
             .OnUpdate(() => _shakeRoot.localPosition += _shakeOffset)
             .SetUpdate(UpdateType.Late);
+    }
+
+    /// <summary>ループする振動演出を再生</summary>
+    private void ShakeBody(int loop) {
+        // 前回の_shakeSeqがまだ再生中だった場合を考慮して、演出の強制終了メソッドを呼び出し
+        _shakeSeq?.Kill();
+
+        _shakeSeq = DOTween.Sequence()
+            .SetLink(gameObject)
+            .Append(DOTween.Shake(() => Vector3.zero, offset => _shakeOffset = offset, 0.5f, 0.15f, 20, fadeOut: false))
+            .OnUpdate(() => _shakeRoot.localPosition += _shakeOffset)
+            .SetUpdate(UpdateType.Late)
+            .SetLoops(loop);
     }
 
     /// <summary>ノックバック演出</summary>

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -96,6 +96,8 @@ public class Enemy : MonoBehaviour {
     private void AttackReady() {
         // 攻撃準備中フラグを立てる
         _attackReadyFlag = true;
+        // 攻撃準備アニメーションのトリガーを起動
+        _animator.SetTrigger("AttackReady");
         // 移動アニメーションのフラグを降ろす
         _animator.SetBool("IsMove", false);
         // 攻撃準備表現として、体を3回点滅させる
@@ -171,6 +173,8 @@ public class Enemy : MonoBehaviour {
         if (_attackReadyFlag) {
             // 攻撃準備中フラグを降ろす
             _attackReadyFlag = false;
+            // 攻撃準備アニメーションのトリガーをリセットする
+            _animator.ResetTrigger("AttackReady");
             // 登録したAttackのInvokeをキャンセル
             CancelInvoke(nameof(Attack));
         }

--- a/Assets/ThirdParty/RPG Monster Duo PBR Polyart/Animations/Slime/Attack02_Slime_Anim.fbx.meta
+++ b/Assets/ThirdParty/RPG Monster Duo PBR Polyart/Animations/Slime/Attack02_Slime_Anim.fbx.meta
@@ -176,6 +176,119 @@ ModelImporter:
       maskType: 3
       maskSource: {instanceID: 0}
       additiveReferencePoseFrame: 0
+    - serializedVersion: 16
+      name: AttackReady
+      takeName: Take 001
+      internalID: -998496362607748373
+      firstFrame: 0
+      lastFrame: 4
+      wrapMode: 0
+      orientationOffsetY: 0
+      level: 0
+      cycleOffset: 0
+      loop: 0
+      hasAdditiveReferencePose: 0
+      loopTime: 0
+      loopBlend: 0
+      loopBlendOrientation: 0
+      loopBlendPositionY: 0
+      loopBlendPositionXZ: 0
+      keepOriginalOrientation: 0
+      keepOriginalPositionY: 1
+      keepOriginalPositionXZ: 0
+      heightFromFeet: 0
+      mirror: 0
+      bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+      curves: []
+      events: []
+      transformMask:
+      - path: 
+        weight: 1
+      - path: Body
+        weight: 1
+      - path: Body/Spine01
+        weight: 1
+      - path: Body/Spine01/Head
+        weight: 1
+      - path: Body/Spine01/Head/Crown
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL/BottomEyeCover
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL/EyeBall
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL/UpperEyeCover
+        weight: 1
+      - path: Body/Spine01/Side_L
+        weight: 1
+      - path: Body/Spine01/Side_R
+        weight: 1
+      - path: Slime
+        weight: 1
+      maskType: 3
+      maskSource: {instanceID: 0}
+      additiveReferencePoseFrame: 0
+    - serializedVersion: 16
+      name: AttackHit
+      takeName: Take 001
+      internalID: 3060872287085348379
+      firstFrame: 4
+      lastFrame: 25
+      wrapMode: 0
+      orientationOffsetY: 0
+      level: 0
+      cycleOffset: 0
+      loop: 0
+      hasAdditiveReferencePose: 0
+      loopTime: 0
+      loopBlend: 0
+      loopBlendOrientation: 0
+      loopBlendPositionY: 0
+      loopBlendPositionXZ: 0
+      keepOriginalOrientation: 0
+      keepOriginalPositionY: 1
+      keepOriginalPositionXZ: 0
+      heightFromFeet: 0
+      mirror: 0
+      bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+      curves: []
+      events:
+      - time: 0.40808487
+        functionName: AttackImpactEvent
+        data: 
+        objectReferenceParameter: {instanceID: 0}
+        floatParameter: 0
+        intParameter: 0
+        messageOptions: 0
+      transformMask:
+      - path: 
+        weight: 1
+      - path: Body
+        weight: 1
+      - path: Body/Spine01
+        weight: 1
+      - path: Body/Spine01/Head
+        weight: 1
+      - path: Body/Spine01/Head/Crown
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL/BottomEyeCover
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL/EyeBall
+        weight: 1
+      - path: Body/Spine01/Head/EyeCTRL/UpperEyeCover
+        weight: 1
+      - path: Body/Spine01/Side_L
+        weight: 1
+      - path: Body/Spine01/Side_R
+        weight: 1
+      - path: Slime
+        weight: 1
+      maskType: 3
+      maskSource: {instanceID: 0}
+      additiveReferencePoseFrame: 0
     isReadable: 1
   meshes:
     lODScreenPercentages: []


### PR DESCRIPTION
# 実装概要
プレイヤーが「敵がもうすぐ攻撃してくる」ということに気づいて対処しやすいようにするブラッシュアップです。
具体的には、下記が実装されています。

**▼ 0f7c736 攻撃準備状態を追加**
攻撃できる距離まで近づいた後、すぐに攻撃せずに待ち時間(0.3秒)を設けました

**▼ 1161c53 攻撃準備中に色を変える**
マテリアルに白の加算カラーを与えて、数回点滅するDOTweenを再生しています

**▼ 21bdb28 攻撃準備中に振動させる**
DOTween.Shakeを使って振動させています。
DOShakePositionで直接振動させていないのは、振動させるTransform（_shakeRoot）がAnimatorによって更新させるものであるため、明示的に後更新(LateUpdate)で座標更新する必要があるからです。

**▼ f9157df モーション分割でタメを見せる**
攻撃モーションのclipを分割し、攻撃準備中のモーションと攻撃モーションを明確に分離しています。

<img width="683" alt="image" src="https://github.com/fluncle/GCC2023ActionGame/assets/3529208/b8f94a53-291a-44ea-9079-f193a4db70f7">

サンプルのスライムの3Dモデルだとちょっとわかりづらいですが、拳や武器を振りかぶるようなモーションで「敵がもうすぐ攻撃してくる」ということを気づかせるために効果が高いと考えているブラッシュアップです。