### PR TITLE
第５章 機能① - タイムアタック・タイムオーバー

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,132 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &74487343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 74487344}
+  - component: {fileID: 74487349}
+  - component: {fileID: 74487348}
+  - component: {fileID: 74487347}
+  - component: {fileID: 74487346}
+  - component: {fileID: 74487345}
+  m_Layer: 5
+  m_Name: TimeView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &74487344
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74487343}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1163956601}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -70}
+  m_SizeDelta: {x: 1080, y: 200}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &74487345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74487343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.8509804}
+  m_EffectDistance: {x: 5, y: -5}
+  m_UseGraphicAlpha: 1
+--- !u!114 &74487346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74487343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e19747de3f5aca642ab2be37e372fb86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 1, g: 1, b: 1, a: 1}
+  m_EffectDistance: {x: 3, y: -3}
+  m_UseGraphicAlpha: 1
+--- !u!114 &74487347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74487343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.39215687, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 130
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 150
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 02:00
+--- !u!222 &74487348
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74487343}
+  m_CullTransparentMesh: 1
+--- !u!114 &74487349
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74487343}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57fc48cca7649467191f30f758917d0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _text: {fileID: 74487347}
 --- !u!1 &181065059
 GameObject:
   m_ObjectHideFlags: 0
@@ -674,7 +800,7 @@ RectTransform:
   m_Children:
   - {fileID: 736578141}
   m_Father: {fileID: 1163956601}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1337,7 +1463,7 @@ RectTransform:
   - {fileID: 270274623}
   - {fileID: 1549914651}
   m_Father: {fileID: 1163956601}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1852,6 +1978,7 @@ RectTransform:
   m_Children:
   - {fileID: 428307029}
   - {fileID: 812186143}
+  - {fileID: 74487344}
   - {fileID: 613452975}
   - {fileID: 817051917}
   m_Father: {fileID: 0}
@@ -1876,6 +2003,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _playerHPGauge: {fileID: 812186146}
   _gameEndView: {fileID: 817051920}
+  _timeView: {fileID: 74487349}
 --- !u!1 &1240954457
 GameObject:
   m_ObjectHideFlags: 0
@@ -2212,6 +2340,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _player: {fileID: 3172645344870299905}
+  _maxTime: 120
 --- !u!4 &1561050110
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -77,8 +77,8 @@ public class Enemy : MonoBehaviour {
     /// <summary>更新処理</summary>
     private void Update() {
         var player = GameManager.Instance.Player;
-        if (_attackReadyFlag || _attackFlag || _damageFlag || _hp <= 0 ||  player.IsDead) {
-            // 攻撃準備中、攻撃中、ダメージ中、死亡時、またはプレイヤー死亡時は何もしない
+        if (_attackReadyFlag || _attackFlag || _damageFlag || _hp <= 0 ||  player.IsDead || GameManager.Instance.IsTimeOver) {
+            // 攻撃準備中、攻撃中、ダメージ中、死亡時、プレイヤー死亡時、時間切れ時は何もしない
             return;
         }
 

--- a/Assets/Scripts/EnemyManager.cs
+++ b/Assets/Scripts/EnemyManager.cs
@@ -8,6 +8,9 @@ public class EnemyManager : MonoBehaviour {
     /// <summary>ゲーム内で生きている敵リスト</summary>
     private List<Enemy> _enemies;
 
+    /// <summary>敵が存在するか否か</summary>
+    public bool IsExistEnemy => _enemies.Count > 0;
+
     private void Awake() {
         Instance = this;
         // 子オブジェクト内から全てのEnemyコンポーネントを検索して取得
@@ -28,7 +31,7 @@ public class EnemyManager : MonoBehaviour {
         _enemies.Remove(enemy);
         Destroy(enemy.gameObject);
 
-        if (_enemies.Count <= 0 && !GameManager.Instance.Player.IsDead) {
+        if (!IsExistEnemy && !GameManager.Instance.Player.IsDead) {
             // 敵リスト内の敵の数が0になっていたらゲームクリア演出を呼び出し
             // ただし、既にプレイヤーが死亡していたらクリア演出は呼ばない
             GameUIManager.Instance.GameEndView.Play(true);

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -9,14 +9,47 @@ public class GameManager : MonoBehaviour {
     public Player Player => _player;
     [SerializeField] private Player _player;
 
+    /// <summary>ゲーム時間</summary>
+    [SerializeField] private int _maxTime;
+    
+    /// <summary>ゲーム時間のカウント</summary>
+    private float _time;
+    
+    /// <summary>時間切れか否か</summary>
+    public bool IsTimeOver => _time <= 0f;
+
     /// <summary>起動時の処理</summary>
     private void Awake() {
         Instance = this;
+        _time = _maxTime;
+    }
+
+    /// <summary>実行開始前の処理</summary>
+    private void Start() {
+        // GameUIManager.InstanceはAwakeで設定されるので、Startでアクセスする
+        GameUIManager.Instance.TimeView.SetTime(_time);
     }
 
     /// <summary>ゲームリセット</summary>
     public void ResetScene() {
         // ゲームシーンを読み込むことでリセットする
         SceneManager.LoadScene(0);
+    }
+
+    /// <summary>更新処理</summary>
+    private void Update() {
+        if (IsTimeOver || !EnemyManager.Instance.IsExistEnemy) {
+            // 残り時間が既に0か、ゲームクリア済みなら処理を抜ける
+            return;
+        }
+        
+        // 経過時間を減算。ただし、0未満にならないようにする
+        _time = Mathf.Max(_time - Time.deltaTime, 0f);
+        GameUIManager.Instance.TimeView.SetTime(_time);
+        
+        if (IsTimeOver) {
+            // 残り時間が0になったらゲームオーバー
+            GameUIManager.Instance.GameEndView.Play(false);
+        }
     }
 }

--- a/Assets/Scripts/GameUIManager.cs
+++ b/Assets/Scripts/GameUIManager.cs
@@ -16,6 +16,10 @@ public class GameUIManager : MonoBehaviour {
     public GameEndView GameEndView => _gameEndView;
     [SerializeField] private GameEndView _gameEndView;
 
+    /// <summary>時間表示</summary>
+    public TimeView TimeView => _timeView;
+    [SerializeField] private TimeView _timeView;
+
     /// <summary>起動時の処理</summary>
     private void Awake() {
         Instance = this;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -79,6 +79,11 @@ public class Player : MonoBehaviour {
 
     /// <summary>更新処理</summary>
     private void Update() {
+        if (GameManager.Instance.IsTimeOver) {
+            // 時間切れ時は処理を抜ける
+            return;
+        }
+
         if (_attackFlag) {
             UpdateAttackRotate();
             UpdateAttackAdvance();

--- a/Assets/Scripts/TimeView.cs
+++ b/Assets/Scripts/TimeView.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>時間表示</summary>
+public class TimeView : MonoBehaviour {
+    [SerializeField] private Text _text;
+
+    /// <summary>秒数を渡して分:秒に変換して表示</summary>
+    public void SetTime(float time) {
+        var minutes = Mathf.FloorToInt(time / 60f);
+        var seconds = Mathf.FloorToInt(time % 60f);
+         _text.text = $"{minutes:00}:{seconds:00}";
+    }
+}

--- a/Assets/Scripts/TimeView.cs.meta
+++ b/Assets/Scripts/TimeView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57fc48cca7649467191f30f758917d0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 実装概要

画面上部に時間を表示して、ゲーム中にカウントダウンをする機能です。
ゲームクリア時のクリアタイムと、時間切れによるゲームオーバーをセットで実装しています。

この機能をunitypackageなどで受講者さんに渡して、
演習として既存機能をブラッシュアップしてもらう用途を想定しています。

#### ▼例
- 開始前のREADY表示
- 一定時間以下になったら、カウントダウン数字をコンマ１秒以下を表示
- 残り時間10秒になったら警告演出
- 残り時間が半分になったら通知